### PR TITLE
Prevent infinite loop between State and EnteringState

### DIFF
--- a/Lua/Libraries/CYK/CYKCore.lua
+++ b/Lua/Libraries/CYK/CYKCore.lua
@@ -673,7 +673,11 @@ return function ()
         end
 
         -- Calls EnteringState at the start of the function
-        EnteringState(newState, self.state, true)
+        if not self.stateLock then
+            self.stateLock = true
+            EnteringState(newState, self.state, true)
+        end
+        self.stateLock = nil
         -- If the state has been changed, don't go any further
         if self.state ~= oldState then return end
 


### PR DESCRIPTION
Currently, by calling `State` inside of `EnteringState`, it's possible to force the engine into an infinite loop.

For example:

```lua
function EnteringState(newstate, oldstate)
    if newstate != "ATTACKING" and oldstate == "ATTACKING" then
        State("ENEMYDIALOGUE")
    end
end
```

In CYF and even Unitale, calling `State` from inside of `EnteringState` will skip over the part that calls `EnteringState` again. I have re-made this behavior in this commit/PR to prevent needless crashes with code that would work in CYF but not CYK.