### PR TITLE
Fix Arena.rotation

### DIFF
--- a/Lua/Libraries/CYK/Sandboxing/WaveBegin.lua
+++ b/Lua/Libraries/CYK/Sandboxing/WaveBegin.lua
@@ -76,7 +76,7 @@ function Arena.MoveToAndResize(x, y, width, height, movePlayer, immediate) _Aren
 -- New Arena functions and values
 getset.defineProperty(Arena, "inner",    { get = function() return FakeArena.arena["inner"] end, set = function(value) error("Can't set the Arena's inner sprite!") end })
 getset.defineProperty(Arena, "outer",    { get = function() return FakeArena.arena          end, set = function(value) error("Can't set the Arena's outer sprite!") end })
-getset.defineProperty(Arena, "rotation", { get = function() return FakeArena.arena.rotation end, set = function(value) FakeArena.RotateArena(rot, false)            end })
+getset.defineProperty(Arena, "rotation", { get = function() return FakeArena.arena.rotation end, set = function(value) FakeArena.RotateArena(value, false)            end })
 
 function Arena.Update() FakeArena.Update() end
 

--- a/Lua/Libraries/CYK/TextManager.lua
+++ b/Lua/Libraries/CYK/TextManager.lua
@@ -127,11 +127,11 @@ return function(CYK)
                     local commandName = string.split(command, ":")[1]
                     -- Remove any func, color or alpha call
                     if commandName == "func" or commandName == "color" or commandName == "alpha" then
-                        text = string.sub(text, 1, bracketBegin - 1) .. (#text < index and "" or string.sub(text, index + 1, #text))
+                        text = string.sub(text, 1, bracketBegin - 1) .. (#text > index and "" or string.sub(text, index + 1, #text))
                         index = bracketBegin - 1
                     -- Add [novoice] to any font or voice call
                     elseif commandName == "font" or commandName == "voice" then
-                        text = string.sub(text, 1, index) .. "[novoice]" .. (#text < index and "" or string.sub(text, index + 1, #text))
+                        text = string.sub(text, 1, index) .. "[novoice]" .. (#text > index and "" or string.sub(text, index + 1, #text))
                         index = index + 9
                     end
                     bracketBegin = -1

--- a/Lua/Libraries/CYK/TextManager.lua
+++ b/Lua/Libraries/CYK/TextManager.lua
@@ -127,11 +127,11 @@ return function(CYK)
                     local commandName = string.split(command, ":")[1]
                     -- Remove any func, color or alpha call
                     if commandName == "func" or commandName == "color" or commandName == "alpha" then
-                        text = string.sub(text, 1, bracketBegin - 1) .. (#text > index and "" or string.sub(text, index + 1, #text))
+                        text = string.sub(text, 1, bracketBegin - 1) .. (#text < index and "" or string.sub(text, index + 1, #text))
                         index = bracketBegin - 1
                     -- Add [novoice] to any font or voice call
                     elseif commandName == "font" or commandName == "voice" then
-                        text = string.sub(text, 1, index) .. "[novoice]" .. (#text > index and "" or string.sub(text, index + 1, #text))
+                        text = string.sub(text, 1, index) .. "[novoice]" .. (#text < index and "" or string.sub(text, index + 1, #text))
                         index = index + 9
                     end
                     bracketBegin = -1


### PR DESCRIPTION
Fixed `Arena.rotation`'s sandboxing function having the wrong variable name, which meant the property was completely unusable