### PR TITLE
Fix SilenceText cancelling out future asterisks after some commands

### DIFF
--- a/Lua/Libraries/CYK/TextManager.lua
+++ b/Lua/Libraries/CYK/TextManager.lua
@@ -127,11 +127,11 @@ return function(CYK)
                     local commandName = string.split(command, ":")[1]
                     -- Remove any func, color or alpha call
                     if commandName == "func" or commandName == "color" or commandName == "alpha" then
-                        text = string.sub(text, 1, bracketBegin - 1) .. (#text > index and "" or string.sub(text, index + 1, #text))
+                        text = string.sub(text, 1, bracketBegin - 1) .. (#text < index and "" or string.sub(text, index + 1, #text))
                         index = bracketBegin - 1
                     -- Add [novoice] to any font or voice call
                     elseif commandName == "font" or commandName == "voice" then
-                        text = string.sub(text, 1, index) .. "[novoice]" .. (#text > index and "" or string.sub(text, index + 1, #text))
+                        text = string.sub(text, 1, index) .. "[novoice]" .. (#text < index and "" or string.sub(text, index + 1, #text))
                         index = index + 9
                     end
                     bracketBegin = -1


### PR DESCRIPTION
Fixed a bug involving the second text manager that handles asterisks. Previously, any instance of certain text commands (func, color, alpha, font and voice) would always prevent this text manager from showing any future asterisks, as it would treat the string as already finished. This was due to an inverted condition, which I flipped around into the correct position.

This especially includes user-defined asterisks that come after the command(s) in question.

&nbsp;

An example, as promised:

string:
```lua
BattleDialog({"Ralsei casts [color:ffd800]Heal Prayer[color:ffffff]\ron Kris![w:5]\nKris's INFLUENCE got maxed out!"})
```
(pay attention to the `\n` just before "Kris's INFLUENCE")

Without fix:
![no fix](https://cdn.discordapp.com/attachments/294341563683831819/638501004437880852/before.png)

With fix:
![no fix](https://cdn.discordapp.com/attachments/294341563683831819/638501004664373296/after.png)