### PR TITLE
Fix Entity.MoveTo

### DIFF
--- a/Lua/Libraries/CYK/Sandboxing/Entity.lua
+++ b/Lua/Libraries/CYK/Sandboxing/Entity.lua
@@ -141,9 +141,9 @@ function MoveTo(x, y)
         error("entity.MoveTo() needs two numbers as arguments.")
     end
     sprite.x = x
-    posX = absx
+    posX = sprite.absx
     sprite.y = y
-    posY = absy
+    posY = sprite.absy
 end
 
 -- Moves the entity from the bottom left corner of the screen


### PR DESCRIPTION
Fixes `posX` and `posY` being set to `nil` after using `Entity.MoveTo`. This previously caused error screens when attacking the enemy after using the function.