### PR TITLE
Fix `sprite.loopmode` on entity Masks

### DIFF
--- a/Lua/Libraries/CYK/Animation.lua
+++ b/Lua/Libraries/CYK/Animation.lua
@@ -94,6 +94,7 @@ return function(self)
         sprite.SetAnimation(animObject[1], animObject[2])
         -- Don't forget the sprite's mask
         if sprite["mask"] then
+            sprite["mask"].loopmode = loopmode
             sprite["mask"].SetAnimation(animObject[1], animObject[2])
         end
     end


### PR DESCRIPTION
Fixes entity animations that don't loop causing the entity's mask sprite to loop anyway, producing some strange results (see below examples):

![Gif demonstration one.](https://cdn.discordapp.com/attachments/570776498173378605/678109195853103104/llN92sZ3Bl.gif)
![Gif demonstration one.](https://cdn.discordapp.com/attachments/570776498173378605/678111490523529226/p50PYTqFfM.gif)